### PR TITLE
Relocate Copy Kết Quả button near totals heading

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -420,22 +420,33 @@ function App() {
 
                 {id && (
                     <div style={{ marginTop: 20 }}>
-                        <h4>📊 Túc Số Hôm Nay / Tổng Tích Lũy – {dharmaName}</h4>
-                        <button
-                            onClick={copyResult}
+                        <div
                             style={{
-                                padding: '6px 12px',
-                                fontSize: 14,
-                                backgroundColor: '#007bff',
-                                color: 'white',
-                                border: 'none',
-                                borderRadius: 4,
-                                cursor: 'pointer',
-                                marginTop: 8,
+                                display: 'flex',
+                                flexWrap: 'wrap',
+                                alignItems: 'center',
+                                gap: 12,
+                                marginBottom: 12,
                             }}
                         >
-                            📋 Copy Kết Quả
-                        </button>
+                            <h4 style={{ margin: 0 }}>
+                                📊 Túc Số Hôm Nay / Tổng Tích Lũy – {dharmaName}
+                            </h4>
+                            <button
+                                onClick={copyResult}
+                                style={{
+                                    padding: '6px 12px',
+                                    fontSize: 14,
+                                    backgroundColor: '#007bff',
+                                    color: 'white',
+                                    border: 'none',
+                                    borderRadius: 4,
+                                    cursor: 'pointer',
+                                }}
+                            >
+                                📋 Copy Kết Quả
+                            </button>
+                        </div>
                         {streak > 0 && (
                             <p>
                                 🎉 Đã thực hành <strong>{streak}</strong> ngày liên tục!

--- a/src/App.js
+++ b/src/App.js
@@ -406,7 +406,7 @@ function App() {
 
                 <hr />
 
-                {/* “Gửi dữ liệu” and “Copy Kết Quả” side by side */}
+                {/* “Gửi dữ liệu” button */}
                 <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                     <button
                         onClick={handleSubmit}
@@ -415,26 +415,27 @@ function App() {
                     >
                         ✅ Gửi Dữ Liệu
                     </button>
-                    <button
-                        onClick={copyResult}
-                        style={{
-                            padding: '6px 12px',
-                            fontSize: 14,
-                            backgroundColor: '#007bff',
-                            color: 'white',
-                            border: 'none',
-                            borderRadius: 4,
-                            cursor: 'pointer',
-                        }}
-                    >
-                        📋 Copy Kết Quả
-                    </button>
                 </div>
                 {loading && <p>⏳ Đang xử lý...</p>}
 
                 {id && (
                     <div style={{ marginTop: 20 }}>
                         <h4>📊 Túc Số Hôm Nay / Tổng Tích Lũy – {dharmaName}</h4>
+                        <button
+                            onClick={copyResult}
+                            style={{
+                                padding: '6px 12px',
+                                fontSize: 14,
+                                backgroundColor: '#007bff',
+                                color: 'white',
+                                border: 'none',
+                                borderRadius: 4,
+                                cursor: 'pointer',
+                                marginTop: 8,
+                            }}
+                        >
+                            📋 Copy Kết Quả
+                        </button>
                         {streak > 0 && (
                             <p>
                                 🎉 Đã thực hành <strong>{streak}</strong> ngày liên tục!


### PR DESCRIPTION
## Summary
- move the Copy Kết Quả button from the submission row to the totals section
- ensure the button now appears between the totals heading and the 21-day chart

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7e1400250832480bfbd57907e3637